### PR TITLE
Fix repository link in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "travis": "npm run lint && npm run coverage",
     "submit-coveralls": "<coverage/lcov.info coveralls"
   },
-  "repository": {
-    "type": "git",
-    "url": "github.com/gustavnikolaj/hijackresponse"
-  },
+  "repository": "gustavnikolaj/hijackresponse",
   "author": "Gustav Nikolaj <gustavnikolaj@gmail.com>",
   "contributors": [
     "Andreas Lind <andreas@one.com>"


### PR DESCRIPTION
Current link didn't work, and was not used at https://www.npmjs.com/package/hijackresponse

This should fix it by using the github short form.
