### PR TITLE
Relay the 'close' event from the original res to the hijacked response.

### DIFF
--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -51,6 +51,10 @@ module.exports = function hijackResponse (res, cb, readableOptions) {
     }
   }
 
+  res.once('close', function () {
+    hijackedResponse.emit('close')
+  })
+
   hijackedResponse.write = function (chunk, encoding) {
     write.call(originalResponse, chunk, encoding)
   }

--- a/test/hijackResponse.spec.js
+++ b/test/hijackResponse.spec.js
@@ -1,6 +1,7 @@
-/* global describe, it */
+/* global describe, it, beforeEach, afterEach */
 var expect = require('./unexpected-with-plugins')
 var passError = require('passerror')
+var http = require('http')
 var hijackResponse = require('../')
 
 describe('hijackResponse', function () {
@@ -324,6 +325,45 @@ describe('hijackResponse', function () {
           res.end()
         }, 10)
       }, 'to yield response', 'foobar')
+    })
+  })
+  describe('against a real server', function () {
+    var handleRequest
+    var server
+    var serverAddress
+    var serverHostname
+    var serverUrl
+    beforeEach(function () {
+      handleRequest = undefined
+      server = http.createServer(function (req, res) {
+        res.sendDate = false
+        handleRequest(req, res)
+      }).listen(0)
+      serverAddress = server.address()
+      serverHostname = serverAddress.address === '::' ? 'localhost' : serverAddress.address
+      serverUrl = 'http://' + serverHostname + ':' + serverAddress.port + '/'
+    })
+    afterEach(function () {
+      server.close()
+    })
+    it('should emit the close event on the hijacked response', function () {
+      return expect.promise(function (run) {
+        handleRequest = run(function (req, res) {
+          hijackResponse(res, run(function (err, res) {
+            expect(err, 'to be falsy')
+            res.on('close', run(function () {}))
+          }))
+          res.end('yaddayadda')
+        })
+        var request = http.get(serverUrl)
+        request.end('foo')
+        setTimeout(function () {
+          request.abort()
+        }, 10)
+        request.on('error', run(function (err) {
+          expect(err, 'to have message', 'socket hang up')
+        }))
+      })
     })
   })
 })


### PR DESCRIPTION
This reintroduces the ability to detect when the client closes the connection prematurely.
