### PR TITLE
Preserving "close" Event Listeners On Response

### DIFF
--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -51,9 +51,9 @@ module.exports = function hijackResponse (res, cb) {
   res.emit = function (eventName) {
     if (eventName === 'close') {
       hijackedResponse.emit('close')
-    } else {
-      return resEmit.apply(this, arguments)
     }
+
+    return resEmit.apply(this, arguments)
   }
 
   hijackedResponse.destroyHijacked = function () {

--- a/test/express.js
+++ b/test/express.js
@@ -1,13 +1,16 @@
-/* global describe, it */
+/* global describe, it, before, after */
+var http = require('http')
 var expect = require('unexpected')
   .clone()
   .use(require('unexpected-express'))
+  .use(require('unexpected-sinon'))
   .addAssertion('to yield response', function (expect, subject, value) {
     return expect(subject, 'to yield exchange', {
       request: 'GET /',
       response: value
     })
   })
+var sinon = require('sinon')
 var express = require('express')
 var passError = require('passerror')
 var hijackResponse = require('../')
@@ -162,5 +165,66 @@ describe('Express Integration Tests', function () {
         response: { body: /^0{1999998}$/ }
       }
     )
+  })
+  describe('against a real server', function () {
+    before(function () {
+      var self = this
+      var spy = sinon.spy()
+
+      this.spy = spy
+
+      return new Promise(function (resolve) {
+        var app = express()
+          .use(function (req, res, next) {
+            res.on('close', function () {
+              spy()
+              self.resolve()
+            })
+
+            next()
+          })
+          .use(function (req, res, next) {
+            hijackResponse(res, passError(next, function (res) {
+              res.pipe(res)
+            }))
+
+            next()
+          })
+          .use(function (req, res) {
+            res.write('foo')
+          })
+
+        var server = http.Server(app)
+        server.listen(0, function () {
+          resolve(server)
+        })
+      }).then(function (server) {
+        self.server = server
+      })
+    })
+    it('should not prevent "close" events registered on res from firing when hijacking', function () {
+      var self = this
+      var port = this.server.address().port
+      var spy = this.spy
+
+      return new Promise(function (resolve) {
+        self.resolve = resolve
+
+        var options = {
+          port: port
+        }
+
+        var request = http.request(options, function (res) {
+          request.abort()
+        })
+
+        request.end()
+      }).then(function () {
+        expect(spy, 'was called')
+      })
+    })
+    after(function () {
+      this.server.close()
+    })
   })
 })


### PR DESCRIPTION
I couldn't figure out yet how to properly handle the `close` event in hijackresponse, but wrote the test that shows that existing `close` event listeners will not be fired when hijackresponse is in the picture.

Removing [those lines]( https://github.com/PabloSichert/hijackresponse/blob/c7a8278cce80931e5e709ec889b06de816b1bbc9/test/express.js#L187-L189) will make the test pass.

@papandreou @joelmukuthu

Code example:

```js
app.use((req, res, next) => {
    const start = new Date;

    const log = () => {
        console.log(new Date - start);
    };

    res.on('close', log); // Attaching it to the hijacked response also doesn't work

    hijackResponse(res, (err, res) {
        log();

        if (err) {
            next(err);
            return;
        }

        res.pipe(res);
    });

    next();
});

```