### PR TITLE
Whitelist package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   "contributors": [
     "Andreas Lind <andreaslindpetersen@gmail.com>"
   ],
+  "files": [
+    "lib"
+  ],
   "license": "ISC"
 }


### PR DESCRIPTION
This brings the size of the package down from 2 MB to 7.9 kB.