### PR TITLE
Split stream rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "8"
   - "10"
   - "12"
+  - "14"
 script:
   - npm run lint
   - npm run coverage:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -29,6 +29,13 @@ module.exports = function hijackResponse(res, cb, name) {
     }
   });
 
+  hijackedResponseBody.destroyAndRestore = function destroyAndRestore() {
+    for (const [methodName, method] of Object.entries(__beforePatching)) {
+      res[methodName] = method;
+    }
+    return hijackedResponseBody.destroy();
+  };
+
   const proxyRes = {};
   Object.setPrototypeOf(proxyRes, res);
 

--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -1,18 +1,5 @@
 var Transform = require("stream").Transform;
 
-// Object.entries polyfill for Node 6
-function objectDotEntries(obj) {
-  if (!Object.entries) {
-    var ownProps = Object.keys(obj);
-    var i = ownProps.length;
-    var resArray = new Array(i);
-    while (i--) resArray[i] = [ownProps[i], obj[ownProps[i]]];
-    return resArray;
-  }
-
-  return Object.entries(obj);
-}
-
 module.exports = function hijackResponse(res, cb, name) {
   var implicitHeaderCalled = false;
   function callImplicitHeaderOnce() {
@@ -45,7 +32,7 @@ module.exports = function hijackResponse(res, cb, name) {
   const proxyRes = {};
   Object.setPrototypeOf(proxyRes, res);
 
-  for (const [methodName, method] of objectDotEntries(__beforePatching)) {
+  for (const [methodName, method] of Object.entries(__beforePatching)) {
     proxyRes[methodName] = function() {
       method.apply(res, arguments);
     };

--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -1,105 +1,61 @@
-var Readable = require("stream").Readable;
+var Transform = require("stream").Transform;
 
-module.exports = function hijackResponse(res, cb) {
-  var writeHead = res.writeHead;
-  var write = res.write;
-  var end = res.end;
-  var originalResponse = res;
-  var hijacking = true;
-  var hijackedResponse = new Readable();
-  hijackedResponse.__proto__ = originalResponse; // eslint-disable-line no-proto
+module.exports = function hijackResponse(res, cb, name) {
+  var implicitHeaderCalled = false;
+  function callImplicitHeaderOnce() {
+    if (!implicitHeaderCalled) {
+      res._implicitHeader();
+      implicitHeaderCalled = true;
+    }
+  }
 
-  var readableMethods = Object.keys(Readable.prototype);
+  const __beforePatching = {
+    write: res.write,
+    end: res.end,
+    on: res.on,
+    writeHead: res.writeHead
+  };
 
-  // emit is not included when doing Object.keys on the prototype, but we need
-  // it.
-  readableMethods.push("emit");
-
-  readableMethods.forEach(function(method) {
-    hijackedResponse[method] = Readable.prototype[method].bind(
-      hijackedResponse
-    );
+  const hijackedResponseBody = new Transform({
+    transform(chunk, encoding, callback) {
+      // Almost a PassThrough Stream. We just need to be able to set a boolean
+      // and call a function when the first chunk is being processed.
+      callImplicitHeaderOnce();
+      callback(null, chunk, encoding);
+    },
+    flush(cb) {
+      callImplicitHeaderOnce();
+      cb(null);
+    }
   });
 
-  hijackedResponse._read = function() {};
+  const proxyRes = {};
+  Object.setPrototypeOf(proxyRes, res);
 
-  res.write = function(rawChunk, encoding) {
-    if (!res.headersSent && res.writeHead !== writeHead) res._implicitHeader();
-    if (hijacking) {
-      var chunk = rawChunk;
-      if (
-        rawChunk !== null &&
-        !Buffer.isBuffer(chunk) &&
-        encoding !== "buffer"
-      ) {
-        if (!encoding) {
-          chunk = Buffer.from(rawChunk);
-        } else {
-          chunk = Buffer.from(rawChunk, encoding);
-        }
-      }
-      hijackedResponse.push(chunk);
-    } else {
-      write.call(originalResponse, rawChunk, encoding);
+  for (const [methodName, method] of Object.entries(__beforePatching)) {
+    proxyRes[methodName] = function() {
+      method.apply(res, arguments);
+    };
+    proxyRes[methodName].name = `proxied-${methodName}-${name}`;
+  }
+
+  res.on = function hijackOn(eventName, ...args) {
+    return hijackedResponseBody.on(eventName, ...args);
+  };
+
+  res.write = function hijackWrite(rawChunk, encoding) {
+    if (rawChunk === null) {
+      return hijackedResponseBody.end();
     }
+
+    return hijackedResponseBody.write(rawChunk, encoding);
   };
 
   res.end = function(chunk, encoding) {
-    if (chunk) {
-      res.write(chunk, encoding);
-    } else if (!res.headersSent && res.writeHead !== writeHead) {
-      res._implicitHeader();
-    }
-    if (hijacking) {
-      hijackedResponse.push(null);
-    } else {
-      end.call(originalResponse);
-    }
+    hijackedResponseBody.end(chunk, encoding);
   };
 
-  var resEmit = res.emit;
-  res.emit = function(eventName) {
-    if (eventName === "close") {
-      hijackedResponse.emit("close");
-    }
-
-    return resEmit.apply(this, arguments);
-  };
-
-  hijackedResponse.destroyHijacked = function() {
-    res.write = res.end = function() {};
-    hijackedResponse._readableState.buffer = [];
-    return resEmit.call(res, "close");
-  };
-
-  hijackedResponse.write = function(chunk, encoding) {
-    write.call(originalResponse, chunk, encoding);
-  };
-
-  hijackedResponse.end = function(chunk, encoding) {
-    if (chunk) {
-      write.call(originalResponse, chunk, encoding);
-    }
-    if (hijacking) {
-      end.call(originalResponse);
-    } else {
-      // If unhijacked, delay end-event so pipes don't close too early giving
-      // you a chance to have error handlers work.
-      setImmediate(function() {
-        end.call(originalResponse);
-      });
-    }
-  };
-
-  hijackedResponse.__defineGetter__("statusCode", function() {
-    return originalResponse.statusCode;
-  });
-
-  hijackedResponse.__defineSetter__("statusCode", function(statusCode) {
-    originalResponse.statusCode = statusCode;
-  });
-
-  res.writeHead = function(statusCode, statusMessage, headers) {
+  res.writeHead = function hijackWriteHead(statusCode, statusMessage, headers) {
     if (typeof headers === "undefined" && typeof statusMessage === "object") {
       headers = statusMessage;
       statusMessage = undefined;
@@ -112,14 +68,7 @@ module.exports = function hijackResponse(res, cb) {
         res.setHeader(headerName, headers[headerName]);
       }
     }
-    res.writeHead = writeHead;
-    cb(null, hijackedResponse);
-  };
-
-  hijackedResponse.unhijack = function() {
-    hijacking = false;
-    res.write = write;
-    res.end = end;
-    return originalResponse;
+    res.writeHead = __beforePatching.writeHead;
+    cb(null, hijackedResponseBody, proxyRes);
   };
 };

--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -1,5 +1,18 @@
 var Transform = require("stream").Transform;
 
+// Object.entries polyfill for Node 6
+function objectDotEntries(obj) {
+  if (!Object.entries) {
+    var ownProps = Object.keys(obj);
+    var i = ownProps.length;
+    var resArray = new Array(i);
+    while (i--) resArray[i] = [ownProps[i], obj[ownProps[i]]];
+    return resArray;
+  }
+
+  return Object.entries(obj);
+}
+
 module.exports = function hijackResponse(res, cb, name) {
   var implicitHeaderCalled = false;
   function callImplicitHeaderOnce() {
@@ -32,7 +45,7 @@ module.exports = function hijackResponse(res, cb, name) {
   const proxyRes = {};
   Object.setPrototypeOf(proxyRes, res);
 
-  for (const [methodName, method] of Object.entries(__beforePatching)) {
+  for (const [methodName, method] of objectDotEntries(__beforePatching)) {
     proxyRes[methodName] = function() {
       method.apply(res, arguments);
     };

--- a/lib/hijackResponse.js
+++ b/lib/hijackResponse.js
@@ -36,7 +36,20 @@ module.exports = function hijackResponse(res, cb, name) {
     return hijackedResponseBody.destroy();
   };
 
-  const proxyRes = {};
+  const proxyRes = {
+    get statusCode() {
+      return res.statusCode;
+    },
+    set statusCode(value) {
+      return (res.statusCode = value);
+    },
+    get statusMessage() {
+      return res.statusMessage;
+    },
+    set statusMessage(value) {
+      return (res.statusMessage = value);
+    }
+  };
   Object.setPrototypeOf(proxyRes, res);
 
   for (const [methodName, method] of Object.entries(__beforePatching)) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "4.0.1",
   "description": "Hijack HttpResponses",
   "main": "lib/hijackResponse.js",
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "devDependencies": {
     "bufferedstream": "3.1.1",
     "compression": "^1.7.0",

--- a/test/emitCloseOnRequestAbort.spec.js
+++ b/test/emitCloseOnRequestAbort.spec.js
@@ -32,7 +32,7 @@ describe("with a aborted request", function() {
       handleRequest = run(function(req, res) {
         hijackResponse(
           res,
-          run(function(err, res) {
+          run(function(err, hijackedResponseBody, res) {
             expect(err, "to be falsy");
             res.on(
               "close",


### PR DESCRIPTION
This is a proper breaking change to the API. The diff in the tests are probably the easiest way to show it.

This implementation add support for node 14 (issue #22) and work around the issues that arose by running the old code on node 14 (done in PR #23).

We have had some issues with the existing implementation of hijackresponse with regards to how it worked with backpressure and how nicely it played with other streams, but it mostly worked most of the time, and it definitely worked well enough not to be a problem. I've tried to solve it multiple times, but my mind breaks whenever I try to understand what is going on, and it's remarkably hard to draw down on paper.

This new approach attempt to solve all those problems, by drastically simplifying the API. In the callback function you pass to `hijackResponse` you now get two different streams rather than one.

Before you would get a stream (which we will call res), that was both a Readable and a Writable stream; The readable part is what the downstream middleware thought that it wrote to the response (the actual hijacked response) and the writeable part is the actual response that you can write the modified data to.

Now you instead get two streams: the first is a readable stream (actually, it's a Transform stream, but you should treat it as a Readable) where the response body of the hijacked request - the second one is the actual writable request.

The issue that arose for node 14 was that calling unpipe() on a stream will now also implicitly call pause() - and due to the way we monkeypatched the Readable-stream onto the `res` object, the two streams would now both react to some of those events (e.g. pause). That was caught by a test in our test suite.

I was able to think of two solutions:

1) Filter which events we relayed to the Readable-stream from res - having potential for all sort of other bugs and misbehavior - and entirely cutting us off from ever addressing issues like backpressure. 
2) Properly separate the two streams.

This PR is my take on the latter.

## API Changes

The current readme example looks like this:

```js
app.use(function(req, res, next) {
  hijackResponse(res, function(err, res) {
    if (err) {
      res.unhijack(); // Make the original res object work again
      return next(err);
    }

    res.setHeader("X-Hijacked", "yes!");
    res.removeHeader("Content-Length");

    res.pipe(transformStream).pipe(res);
  });
  next();
});
```

This proposal would change it to:

```js
app.use(function(req, res, next) {
  hijackResponse(res, function(err, hijackedResponseBody, res) {
    if (err) {
      // err is never not null, can be changed in a later update.
      // But for the sake of the example, this is how you unhijack:
      hijackedResponseBody.pipe(res);
      return
    }

    res.setHeader("X-Hijacked", "yes!");
    res.removeHeader("Content-Length");

    hijackedResponseBody.pipe(transformStream).pipe(res);
  });
  next();
});
```

First an foremost - it's a simpler mental model - the res object inside your hijackResponse callback is now just the actual res, as it was before it was hijacked (**ALMOST**).

It also gets rid of a few weird things about the API - such as the `res.pipe(res)` weirdness and the `res.unhijack()` and `res.destroyHijacked()` constructs.

`res.pipe(res)` now just becomes `hijackedResponseBody.pipe(res)` - and if you don't have anything else in your pipe, it would effectively be the same as `res.unhijack()`.

`res.destroyHijacked()` is supposed to discard the body of the hijacked response, which would be replaced by `hijackedResponseBody.destroy()`.

**Edit:** I had to add `hijackedResponseBody.destroyAndRestore()` for some uses of `res.destroyHijacked()` and `res.unhijack()` in express-processimage. A combination of those two methods was used to discard the response so far, and restore `res` enough that calling `next()` with an error would work. `next` from express/final-handler also handles errors coming up after the headers has been sent, so just calling `hijackedResponseBody.destroy()` and restoring the patched methods is enough.

## Example Conversions

- https://github.com/papandreou/express-extractheaders/pull/40
- https://github.com/papandreou/express-processimage/pull/120
- https://github.com/papandreou/express-compiless/pull/46

## Drawbacks to this approach

### 1. Performance Overhead

In the case where you previously would call `res.unhijack()`, it would undo all the modifications to `res` and make the handlers that would have had their responses hijacked write directly to the response stream. With this change, you would, in that situation, now suffer the overhead of the downstream handlers writing through a PassThrough stream, as you would have to unhijack it by using `hijackedResponseBody.pipe(res)`.

This problem can be lessened by using a [minipass](https://github.com/isaacs/minipass) stream instead. We can also make it an optional performance flag.